### PR TITLE
feat: skip automatic resource provider registrations in azurerm provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,8 @@ provider "azuread" {
   tenant_id = var.directory_id
 }
 provider "azurerm" {
-  subscription_id = var.subscription_id == "" ? null : var.subscription_id
+  subscription_id                 = var.subscription_id == "" ? null : var.subscription_id
+  resource_provider_registrations = "none"
   features {}
 }
 


### PR DESCRIPTION
resource providerの自動登録をスキップするようにする
- Microsoft.Authorizationだけ欲しいが、これは`RegistrationFree`となっており登録する必要ない

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#none-1